### PR TITLE
init solution 2

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,7 +5,7 @@ import { Book } from "./model/book";
 
 const BookQuery = gql`
   query Home {
-    books(author: "Doe") {
+    books(author: "John") {
       id
       title
       author

--- a/client/src/apollo/client.ts
+++ b/client/src/apollo/client.ts
@@ -1,5 +1,5 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
-import { extractDirective } from "./util";
+import initBookFieldPolicy from "./field-policies/book";
 
 const createApolloClient = () => {
   const client = new ApolloClient({
@@ -9,30 +9,7 @@ const createApolloClient = () => {
       typePolicies: {
         Query: {
           fields: {
-            books: {
-              // args, context
-              keyArgs(_, ctx) {
-                const { directiveName } = extractDirective(ctx.field);
-                switch (directiveName) {
-                  case "books-from-feed": {
-                    return ["@connection", ["key"]];
-                  }
-                  default:
-                    return [];
-                }
-              },
-
-              merge(existing = [], incoming = [], ctx) {
-                const { directiveName } = extractDirective(ctx.field);
-                switch (directiveName) {
-                  case "books-from-feed": {
-                    return [...existing, ...incoming];
-                  }
-                  default:
-                    return incoming;
-                }
-              },
-            },
+            books: initBookFieldPolicy(),
           },
         },
       },

--- a/client/src/apollo/field-policies/book.ts
+++ b/client/src/apollo/field-policies/book.ts
@@ -1,0 +1,31 @@
+import type { FieldPolicy } from "@apollo/client";
+import { extractDirective } from "../util";
+
+const initBookFieldPolicy = (): FieldPolicy => {
+  return {
+    // args, context
+    keyArgs(_, ctx) {
+      const { directiveName } = extractDirective(ctx.field);
+      switch (directiveName) {
+        case "books-from-feed": {
+          return ["@connection", ["key"]];
+        }
+        default:
+          return [];
+      }
+    },
+
+    merge(existing = [], incoming = [], ctx) {
+      const { directiveName } = extractDirective(ctx.field);
+      switch (directiveName) {
+        case "books-from-feed": {
+          return [...existing, ...incoming];
+        }
+        default:
+          return incoming;
+      }
+    },
+  };
+};
+
+export default initBookFieldPolicy;

--- a/client/src/apollo/util.ts
+++ b/client/src/apollo/util.ts
@@ -1,0 +1,13 @@
+import type { FieldNode } from "graphql";
+
+export const extractDirective = (field: FieldNode | null) => {
+  const directive = field?.directives?.find(
+    (d) => d.name.value === "connection"
+  );
+  let directiveName = "";
+  if (directive && directive.arguments && directive.arguments[0]) {
+    // @ts-ignore
+    directiveName = directive.arguments[0].value.value;
+  }
+  return { directive, directiveName };
+};

--- a/client/src/components/Feed/Feed.tsx
+++ b/client/src/components/Feed/Feed.tsx
@@ -4,7 +4,7 @@ import { Book } from "../../model/book";
 
 const BookQuery = gql`
   query Feed($page: Int) {
-    books(author: "John", page: $page) {
+    books(author: "John", page: $page) @connection(key: "books-from-feed") {
       id
       title
       author

--- a/client/src/components/Feed/Feed.tsx
+++ b/client/src/components/Feed/Feed.tsx
@@ -1,5 +1,5 @@
 import { gql, useQuery } from "@apollo/client";
-import { useCallback, useRef } from "react";
+import { memo, useCallback, useRef } from "react";
 import { Book } from "../../model/book";
 
 const BookQuery = gql`
@@ -57,4 +57,6 @@ const Feed = () => {
   );
 };
 
-export default Feed;
+const FeedMemo = memo(Feed);
+
+export default FeedMemo;


### PR DESCRIPTION
- This is improvement from solution1, where we separate the cache for home and feed, using connection directive. It's like putting metadata in our query without changing our current query argument requirement. 
- After this solution, there is still one improvement left, what happen if the Feed can filter by author? See what happen to the cache! How to solve it